### PR TITLE
Update wolfssl-py for use with urllib3 and websocket-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: required
 
-branches:
-  only:
-    - master
-
 matrix:
   include:
     - dist: trusty
@@ -13,7 +9,7 @@ matrix:
       script:
         - ./make/manylinux1/build_wheels.sh
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       script:
         - ./make/osx/build_wheels.sh
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Welcome
 that encapsulates `wolfSSL's SSL/TLS library
 <https://wolfssl.com/wolfSSL/Products-wolfssl.html>`_.
 
-**wolfSSL's SSL/TLS library** is a lightweight, portable, C-language-based
+The **wolfSSL SSL/TLS library** is a lightweight, portable, C-language-based
 library targeted at IoT, embedded, and RTOS environments primarily because of
 its size, speed, and feature set. It works seamlessly in desktop, enterprise,
 and cloud environments as well.
@@ -22,3 +22,42 @@ We provide Python wheels (prebuilt binaries) for OSX 64 bits and Linux 64 bits:
 .. code-block:: bash
 
     $ pip install wolfssl
+
+To build wolfssl-py from source:
+
+.. code-block:: bash
+
+    $ cd wolfssl-py
+    $ pip install .
+
+The default pip install clones wolfSSL from GitHub. To build wolfssl-py using a
+local installation of the native wolfSSL C library, the USE_LOCAL_WOLFSSL
+environment variable should be set.  USE_LOCAL_WOLFSSL can be set to "1" to use
+the default library installation location (/usr/local/lib, /usr/local/include),
+or to use a custom location it can be set to the install locaiton of your native
+wolfSSL library.  For example:
+
+.. code-block:: bash
+
+    # Uses default install location
+    $ USE_LOCAL_WOLFSSL=1 pip install .
+
+    # Uses custom install location
+    $ USE_LOCAL_WOLFSSL=/tmp/install pip install .
+
+Tests
+=====
+
+To run the tests that ship with wolfssl-py, after compiling the library run
+one of the following commands:
+
+.. code-block:: bash
+
+    $ pytest
+    $ py.test tests
+
+Support
+=======
+
+For support and questions, please email support@wolfssl.com.
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Sphinx documentation
 #
-# Copyright (C) 2006-2018 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'wolfssl Python'
-copyright = u'2018, wolfSSL Inc. All rights reserved'
+copyright = u'2019, wolfSSL Inc. All rights reserved'
 author = u'wolfSSL'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/examples/client.py
+++ b/examples/client.py
@@ -4,7 +4,7 @@
 #
 # client.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/examples/client.py
+++ b/examples/client.py
@@ -105,6 +105,9 @@ def main():
 
     bind_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
 
+    # enable debug, if native wolfSSL has been compiled with '--enable-debug'
+    wolfssl.WolfSSL.enable_debug()
+
     context = wolfssl.SSLContext(get_method(args.v))
 
     context.load_cert_chain(args.c, args.k)

--- a/examples/server.py
+++ b/examples/server.py
@@ -109,6 +109,9 @@ def main():
 
     print("Server listening on port", bind_socket.getsockname()[1])
 
+    # enable debug, if native wolfSSL has been compiled with '--enable-debug'
+    wolfssl.WolfSSL.enable_debug()
+
     context = wolfssl.SSLContext(get_method(args.v), server_side=True)
 
     context.load_cert_chain(args.c, args.k)

--- a/examples/server.py
+++ b/examples/server.py
@@ -4,7 +4,7 @@
 #
 # server.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/make/manylinux1/build.sh
+++ b/make/manylinux1/build.sh
@@ -11,7 +11,7 @@ for PYBIN in /opt/python/*/bin; do
 done
 
 # Bundle external shared libraries into the wheels
-for whl in dist/*.whl; do
+for whl in dist/wolfssl*.whl; do
     auditwheel repair "$whl" -w tmpdist/
 done
 

--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -2,15 +2,29 @@ set -e
 set +x
 
 for PYVERSION in 2.7 3.4 3.5 3.6; do
-    virtualenv -p /Library/Frameworks/Python.framework/Versions/${PYVERSION}/bin/python${PYVERSION} venv_${PYVERSION}
+    PYTHONBIN=/Library/Frameworks/Python.framework/Versions/${PYVERSION}/bin
+    PYTHONEXE=${PYTHONBIN}/python${PYVERSION}
+    export PATH="${PYTHONBIN}":$PATH
+
+    # update pip for newer TLS support
+    curl https://bootstrap.pypa.io/get-pip.py | ${PYTHONEXE}
+    "${PYTHONBIN}/pip" install --upgrade pip
+
+    # update virtualenv
+    ${PYTHONEXE} -m pip install virtualenv
+
+    virtualenv -p ${PYTHONEXE} venv_${PYVERSION}
     . ./venv_${PYVERSION}/bin/activate
-    pip install -r requirements/setup.txt
-    python setup.py bdist_wheel
-    pip install -r requirements/test.txt
+
+    # install cffi module
+    ${PYTHONEXE} -m pip install cffi
+
+    ${PYTHONEXE} setup.py bdist_wheel
+    "${PYTHONBIN}/pip" install -r requirements/test.txt
     set +e
-    pip uninstall -y wolfssl
+    "${PYTHONBIN}/pip" uninstall -y wolfssl
     set -e
-    pip install wolfssl --no-index -f dist
+    "${PYTHONBIN}/pip" install wolfssl --no-index -f dist
     rm -rf tests/__pycache__
     py.test tests
     deactivate

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,11 @@ class cffiBuilder(build_ext, object):
     def build_extension(self, ext):
         """ Compile manually the wolfssl-py extension, bypass setuptools
         """
-        build_wolfssl(wolfssl.__wolfssl_version__)
+
+        # if USE_LOCAL_WOLFSSL environment variable has been defined,
+        # do not clone and compile wolfSSL from GitHub
+        if os.environ.get("USE_LOCAL_WOLFSSL") is None:
+            build_wolfssl(wolfssl.__wolfssl_version__)
 
         super(cffiBuilder, self).build_extension(ext)
 

--- a/setup.py
+++ b/setup.py
@@ -44,17 +44,6 @@ with open("LICENSING.rst") as licensing_file:
     long_description = long_description.replace(".. include:: LICENSING.rst\n",
                                                 licensing_file.read())
 
-
-# requirements
-install_requires = [
-    'cffi'
-]
-test_requires = [
-    'tox'
-    'pytest'
-]
-
-
 class cffiBuilder(build_ext, object):
 
     def build_extension(self, ext):
@@ -67,7 +56,6 @@ class cffiBuilder(build_ext, object):
             build_wolfssl(wolfssl.__wolfssl_version__)
 
         super(cffiBuilder, self).build_extension(ext)
-
 
 setup(
     name=wolfssl.__title__,
@@ -83,7 +71,6 @@ setup(
     package_dir={"":package_dir},
 
     zip_safe=False,
-    cffi_modules=["./src/wolfssl/_build_ffi.py:ffi"],
 
     keywords="wolfssl, wolfcrypt, security, cryptography",
     classifiers=[
@@ -99,8 +86,10 @@ setup(
         u"Topic :: Software Development"
     ],
 
-    install_requires=install_requires,
+    setup_requires=["cffi"],
+    cffi_modules=["./src/wolfssl/_build_ffi.py:ffi"],
+    install_requires=["cffi"],
     test_suite="tests",
-    tests_require=test_requires,
+    tests_require=["tox", "pytest"],
     cmdclass={"build_ext" : cffiBuilder}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2006-2018 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/setup.py
+++ b/setup.py
@@ -46,16 +46,13 @@ with open("LICENSING.rst") as licensing_file:
 
 
 # requirements
-def _parse_requirements(filepath):
-    raw = pip.req.parse_requirements(
-        filepath, session=pip.download.PipSession())
-
-    return [str(i.req) for i in raw]
-
-
-install_requirements = _parse_requirements("requirements/prod.txt")
-setup_requirements = _parse_requirements("requirements/setup.txt")
-test_requirements = _parse_requirements("requirements/test.txt")
+install_requires = [
+    'cffi'
+]
+test_requires = [
+    'tox'
+    'pytest'
+]
 
 
 class cffiBuilder(build_ext, object):
@@ -102,9 +99,8 @@ setup(
         u"Topic :: Software Development"
     ],
 
-    setup_requires=setup_requirements,
-    install_requires=install_requirements,
+    install_requires=install_requires,
     test_suite="tests",
-    tests_require=test_requirements,
+    tests_require=test_requires,
     cmdclass={"build_ext" : cffiBuilder}
 )

--- a/src/wolfssl/__about__.py
+++ b/src/wolfssl/__about__.py
@@ -26,7 +26,7 @@ __uri__ = "https://github.com/wolfssl/wolfssl-py"
 
 # When bumping the C library version, reset the POST count to 0
 
-__wolfssl_version__ = "v3.14.0b"
+__wolfssl_version__ = "v3.15.5-stable"
 
 # We're using implicit post releases [PEP 440] to bump package version
 # while maintaining the C library version intact for better reference.
@@ -34,7 +34,7 @@ __wolfssl_version__ = "v3.14.0b"
 #
 # MAJOR.MINOR.BUILD-POST
 
-__version__ = __wolfssl_version__[1:].replace("b", "-1")
+__version__ = __wolfssl_version__[1:].replace("stable", "0")
 
 __author__ = "wolfSSL Inc."
 __email__ = "info@wolfssl.com"

--- a/src/wolfssl/__about__.py
+++ b/src/wolfssl/__about__.py
@@ -2,7 +2,7 @@
 #
 # __about__.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #
@@ -40,7 +40,7 @@ __author__ = "wolfSSL Inc."
 __email__ = "info@wolfssl.com"
 
 __license__ = "GPLv2 or Commercial License"
-__copyright__ = "Copyright (C) 2006-2017 wolfSSL Inc"
+__copyright__ = "Copyright (C) 2006-2019 wolfSSL Inc"
 
 __all__ = [
     "__title__", "__summary__", "__uri__", "__version__",

--- a/src/wolfssl/__about__.py
+++ b/src/wolfssl/__about__.py
@@ -26,7 +26,7 @@ __uri__ = "https://github.com/wolfssl/wolfssl-py"
 
 # When bumping the C library version, reset the POST count to 0
 
-__wolfssl_version__ = "v3.15.5-stable"
+__wolfssl_version__ = "v3.15.7-stable"
 
 # We're using implicit post releases [PEP 440] to bump package version
 # while maintaining the C library version intact for better reference.

--- a/src/wolfssl/__init__.py
+++ b/src/wolfssl/__init__.py
@@ -391,7 +391,7 @@ class SSLSocket(object):
 
     def _release_native_object(self):
         if getattr(self, 'native_object', _ffi.NULL) != _ffi.NULL:
-            _lib.wolfSSL_CTX_free(self.native_object)
+            _lib.wolfSSL_free(self.native_object)
             self.native_object = _ffi.NULL
 
     @property

--- a/src/wolfssl/__init__.py
+++ b/src/wolfssl/__init__.py
@@ -2,7 +2,7 @@
 #
 # __init__.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/src/wolfssl/__init__.py
+++ b/src/wolfssl/__init__.py
@@ -176,6 +176,18 @@ class SSLContext(object):
                                         self._verify_mode,
                                         _ffi.NULL)
 
+    def get_options(self):
+        """
+        Wrap native wolfSSL_CTX_get_options() function.
+        """
+        return _lib.wolfSSL_CTX_get_options(self.native_object)
+
+    def set_options(self, value):
+        """
+        Wrap native wolfSSL_CTX_set_options() function.
+        """
+        return _lib.wolfSSL_CTX_set_options(self.native_object, value)
+
     def wrap_socket(self, sock, server_side=False,
                     do_handshake_on_connect=True,
                     suppress_ragged_eofs=True):

--- a/src/wolfssl/__init__.py
+++ b/src/wolfssl/__init__.py
@@ -483,7 +483,11 @@ class SSLSocket(socket):
         self._check_closed("do_handshake")
         self._check_connected()
 
-        ret = _lib.wolfSSL_negotiate(self.native_object)
+        if self.server_side:
+            ret = _lib.wolfSSL_accept(self.native_object)
+        else:
+            ret = _lib.wolfSSL_connect(self.native_object)
+
         if ret != _SSL_SUCCESS:
             raise SSLError("do_handshake failed with error %d" % ret)
 

--- a/src/wolfssl/__init__.py
+++ b/src/wolfssl/__init__.py
@@ -375,6 +375,7 @@ class SSLSocket(object):
             self.ciphers = ciphers
             self.server_hostname = server_hostname
 
+        # set SNI if passed in
         if server_hostname is not None:
             self._context.use_sni(server_hostname)
 

--- a/src/wolfssl/__init__.py
+++ b/src/wolfssl/__init__.py
@@ -114,6 +114,17 @@ class WolfSSLX509(object):
 
         return san
 
+    def get_der(self):
+        outSz = _ffi.new("int *")
+        derPtr = _lib.wolfSSL_X509_get_der(self.native_object, outSz)
+
+        if derPtr == _ffi.NULL:
+            return None
+
+        derBytes = _ffi.buffer(derPtr, outSz[0])
+
+        return derBytes
+
 
 class SSLContext(object):
     """

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -85,6 +85,8 @@ ffi.cdef(
     int  wolfSSL_CTX_load_verify_buffer(void*, const unsigned char*, long,int);
     int  wolfSSL_CTX_use_certificate_chain_file(void*, const char *);
     int  wolfSSL_CTX_UseSNI(void*, unsigned char, const void*, unsigned short);
+    long wolfSSL_CTX_get_options(void*);
+    long wolfSSL_CTX_set_options(void*, long);
 
     /**
      * SSL/TLS Session functions

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -55,6 +55,12 @@ ffi.cdef(
     void  wolfSSL_Free(void*);
 
     /**
+     * Debugging
+     */
+    void wolfSSL_Debugging_ON();
+    void wolfSSL_Debugging_OFF();
+
+    /**
      * SSL/TLS Method functions
      */
     void* wolfTLSv1_1_server_method(void);

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -103,6 +103,7 @@ ffi.cdef(
     int wolfSSL_shutdown(void*);
     void* wolfSSL_get_peer_certificate(void*);
     int wolfSSL_UseSNI(void*, unsigned char, const void*, unsigned short);
+    int wolfSSL_check_domain_name(void*, const char*);
 
     /**
      * WOLFSSL_X509 functions

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -84,6 +84,7 @@ ffi.cdef(
     int  wolfSSL_CTX_load_verify_locations(void*, const char*, const char*);
     int  wolfSSL_CTX_load_verify_buffer(void*, const unsigned char*, long,int);
     int  wolfSSL_CTX_use_certificate_chain_file(void*, const char *);
+    int  wolfSSL_CTX_UseSNI(void*, unsigned char, const void*, unsigned short);
 
     /**
      * SSL/TLS Session functions
@@ -100,6 +101,7 @@ ffi.cdef(
     int wolfSSL_read(void*, void*, int);
     int wolfSSL_shutdown(void*);
     void* wolfSSL_get_peer_certificate(void*);
+    int wolfSSL_UseSNI(void*, unsigned char, const void*, unsigned short);
 
     /**
      * WOLFSSL_X509 functions

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -108,6 +108,7 @@ ffi.cdef(
      */
     char* wolfSSL_X509_get_subjectCN(void*);
     char* wolfSSL_X509_get_next_altname(void*);
+    const unsigned char* wolfSSL_X509_get_der(void*, int*);
     """
 )
 

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -24,7 +24,6 @@
 
 from distutils.util import get_platform
 from cffi import FFI
-from wolfssl.__about__ import __wolfssl_version__ as version
 from wolfssl._build_wolfssl import wolfssl_inc_path, wolfssl_lib_path
 
 ffi = FFI()
@@ -95,6 +94,7 @@ ffi.cdef(
 
     int wolfSSL_set_fd(void*, int);
     int wolfSSL_get_error(void*, int);
+    char* wolfSSL_ERR_error_string(int, char*);
     int wolfSSL_negotiate(void*);
     int wolfSSL_connect(void*);
     int wolfSSL_accept(void*);

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -99,6 +99,13 @@ ffi.cdef(
     int wolfSSL_write(void*, const void*, int);
     int wolfSSL_read(void*, void*, int);
     int wolfSSL_shutdown(void*);
+    void* wolfSSL_get_peer_certificate(void*);
+
+    /**
+     * WOLFSSL_X509 functions
+     */
+    char* wolfSSL_X509_get_subjectCN(void*);
+    char* wolfSSL_X509_get_next_altname(void*);
     """
 )
 

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -88,6 +88,8 @@ ffi.cdef(
     int wolfSSL_set_fd(void*, int);
     int wolfSSL_get_error(void*, int);
     int wolfSSL_negotiate(void*);
+    int wolfSSL_connect(void*);
+    int wolfSSL_accept(void*);
     int wolfSSL_write(void*, const void*, int);
     int wolfSSL_read(void*, void*, int);
     int wolfSSL_shutdown(void*);

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -41,6 +41,20 @@ ffi.set_source(
 
 ffi.cdef(
     """
+
+    /**
+     * Structs
+     */
+    typedef struct WOLFSSL_ALERT {
+        int code;
+        int level;
+    } WOLFSSL_ALERT;
+
+    typedef struct WOLFSSL_ALERT_HISTORY {
+        WOLFSSL_ALERT last_rx;
+        WOLFSSL_ALERT last_tx;
+    } WOLFSSL_ALERT_HISTORY;
+
     /**
      * Types
      */
@@ -104,6 +118,9 @@ ffi.cdef(
     void* wolfSSL_get_peer_certificate(void*);
     int wolfSSL_UseSNI(void*, unsigned char, const void*, unsigned short);
     int wolfSSL_check_domain_name(void*, const char*);
+    int wolfSSL_get_alert_history(void*, WOLFSSL_ALERT_HISTORY*);
+    char* wolfSSL_alert_type_string_long(int);
+    char* wolfSSL_alert_desc_string_long(int);
 
     /**
      * WOLFSSL_X509 functions

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -2,7 +2,7 @@
 #
 # build_ffi.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -25,7 +25,7 @@
 from distutils.util import get_platform
 from cffi import FFI
 from wolfssl.__about__ import __wolfssl_version__ as version
-from wolfssl._build_wolfssl import local_path
+from wolfssl._build_wolfssl import wolfssl_inc_path, wolfssl_lib_path
 
 ffi = FFI()
 
@@ -35,9 +35,8 @@ ffi.set_source(
     #include <wolfssl/options.h>
     #include <wolfssl/ssl.h>
     """,
-    include_dirs=[local_path("lib/wolfssl/src")],
-    library_dirs=[local_path("lib/wolfssl/{}/{}/lib".format(
-        get_platform(), version))],
+    include_dirs=[wolfssl_inc_path()],
+    library_dirs=[wolfssl_lib_path()],
     libraries=["wolfssl"],
 )
 

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -37,6 +37,29 @@ WOLFSSL_GIT_ADDR = "https://github.com/wolfssl/wolfssl.git"
 WOLFSSL_SRC_PATH = local_path("lib/wolfssl/src")
 
 
+def wolfssl_inc_path():
+    wolfssl_path = os.environ.get("USE_LOCAL_WOLFSSL")
+    if wolfssl_path is None:
+        return local_path("lib/wolfssl/src")
+    else:
+        if os.path.isdir(wolfssl_path) and os.path.exists(wolfssl_path):
+            return wolfssl_path + "/include"
+        else:
+            return "/usr/local/include"
+
+
+def wolfssl_lib_path():
+    wolfssl_path = os.environ.get("USE_LOCAL_WOLFSSL")
+    if wolfssl_path is None:
+        return local_path("lib/wolfssl/{}/{}/lib".format(
+                          get_platform(), version))
+    else:
+        if os.path.isdir(wolfssl_path) and os.path.exists(wolfssl_path):
+            return wolfssl_path + "/lib"
+        else:
+            return "/usr/local/lib"
+
+
 def call(cmd):
     print("Calling: '{}' from working directory {}".format(cmd, os.getcwd()))
 

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -106,9 +106,10 @@ def make_flags(prefix):
     """ Returns compilation flags
     """
     flags = []
+    cflags = []
 
     if get_platform() in ["linux-x86_64", "linux-i686"]:
-        flags.append("CFLAGS=-fpic")
+        cflags.append("-fpic")
 
     # install location
     flags.append("--prefix={}".format(prefix))
@@ -120,7 +121,10 @@ def make_flags(prefix):
     # tls 1.3
     flags.append("--enable-tls13")
 
-    return " ".join(flags)
+    joined_flags = " ".join(flags)
+    joined_cflags = " ".join(cflags)
+
+    return joined_flags + " CFLAGS=\"" + joined_cflags + "\""
 
 
 def make(configure_flags):

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 from contextlib import contextmanager
 from distutils.util import get_platform
+from wolfssl.__about__ import __wolfssl_version__ as version
 
 
 def local_path(path):

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -126,6 +126,11 @@ def make_flags(prefix):
     flags.append("--enable-opensslextra")
     cflags.append("-DKEEP_PEER_CERT")
 
+    # websocket-client test server (echo.websocket.org) only supports
+    # TLS 1.2 with TLS_RSA_WITH_AES_128_CBC_SHA
+    # We must enable static RSA suites here
+    cflags.append("-DWOLFSSL_STATIC_RSA")
+
     joined_flags = " ".join(flags)
     joined_cflags = " ".join(cflags)
 

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -150,10 +150,10 @@ def make_flags(prefix):
     flags.append("--enable-opensslextra")
     cflags.append("-DKEEP_PEER_CERT")
 
-    # websocket-client test server (echo.websocket.org) only supports
+    # Note: websocket-client test server (echo.websocket.org) only supports
     # TLS 1.2 with TLS_RSA_WITH_AES_128_CBC_SHA
-    # We must enable static RSA suites here
-    cflags.append("-DWOLFSSL_STATIC_RSA")
+    # If compiling for use with websocket-client, must enable static RSA suites.
+    # cflags.append("-DWOLFSSL_STATIC_RSA")
 
     joined_flags = " ".join(flags)
     joined_cflags = " ".join(cflags)

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -121,11 +121,10 @@ def make_flags(prefix):
     # tls 1.3
     flags.append("--enable-tls13")
 
-    # keep peer cert
-    cflags.append("-DKEEP_PEER_CERT")
-
-    # urllib3 requires SNI
+    # for urllib3 - requires SNI (tlsx), options (openssl compat), peer cert
     flags.append("--enable-tlsx")
+    flags.append("--enable-opensslextra")
+    cflags.append("-DKEEP_PEER_CERT")
 
     joined_flags = " ".join(flags)
     joined_cflags = " ".join(cflags)

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -121,6 +121,9 @@ def make_flags(prefix):
     # tls 1.3
     flags.append("--enable-tls13")
 
+    # keep peer cert
+    cflags.append("-DKEEP_PEER_CERT")
+
     joined_flags = " ".join(flags)
     joined_cflags = " ".join(cflags)
 

--- a/src/wolfssl/_build_wolfssl.py
+++ b/src/wolfssl/_build_wolfssl.py
@@ -124,6 +124,9 @@ def make_flags(prefix):
     # keep peer cert
     cflags.append("-DKEEP_PEER_CERT")
 
+    # urllib3 requires SNI
+    flags.append("--enable-tlsx")
+
     joined_flags = " ".join(flags)
     joined_cflags = " ".join(cflags)
 

--- a/src/wolfssl/_methods.py
+++ b/src/wolfssl/_methods.py
@@ -46,14 +46,6 @@ def _native_free(native_object, dynamic_type):
     _lib.wolfSSL_Free(native_object, _ffi.NULL, dynamic_type)
 
 
-def enable_debug():
-    _lib.wolfSSL_Debugging_ON()
-
-
-def disable_debug():
-    _lib.wolfSSL_Debugging_OFF()
-
-
 class WolfSSLMethod(object):  # pylint: disable=too-few-public-methods
     """
     An SSLMethod holds SSL-related configuration options such as

--- a/src/wolfssl/_methods.py
+++ b/src/wolfssl/_methods.py
@@ -2,7 +2,7 @@
 #
 # _methods.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/src/wolfssl/_methods.py
+++ b/src/wolfssl/_methods.py
@@ -46,6 +46,14 @@ def _native_free(native_object, dynamic_type):
     _lib.wolfSSL_Free(native_object, _ffi.NULL, dynamic_type)
 
 
+def enable_debug():
+    _lib.wolfSSL_Debugging_ON()
+
+
+def disable_debug():
+    _lib.wolfSSL_Debugging_OFF()
+
+
 class WolfSSLMethod(object):  # pylint: disable=too-few-public-methods
     """
     An SSLMethod holds SSL-related configuration options such as

--- a/src/wolfssl/exceptions.py
+++ b/src/wolfssl/exceptions.py
@@ -2,7 +2,7 @@
 #
 # exceptions.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/src/wolfssl/utils.py
+++ b/src/wolfssl/utils.py
@@ -2,7 +2,7 @@
 #
 # utils.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@
 #
 # test_client.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,7 +2,7 @@
 #
 # test_context.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -2,7 +2,7 @@
 #
 # test_methods.py
 #
-# Copyright (C) 2006-2017 wolfSSL Inc.
+# Copyright (C) 2006-2019 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #


### PR DESCRIPTION
This PR is a substantial update to wolfssl-py, fixing bugs and adding features to support use with modified versions of urllib3 and websocket-client.

Changes include:
- Update wolfSSL version to 3.15.7
- Wrap additional native functionality:
    - wolfSSL_Debugging_ON/OFF()
    - wolfSSL_CTX_UseSNI()
    - wolfSSL_CTX_get/set_options()
    - wolfSSL_ERR_error_string()
    - wolfSSL_connect()
    - wolfSSL_accept()
    - wolfSSL_get_peer_certificate()
    - wolfSSL_UseSNI()
    - wolfSSL_check_domain_name()
    - wolfSSL_get_alert_history()
    - wolfSSL_alert_type_string_long()
    - wolfSSL_alert_desc_string_long()
    - wolfSSL_X509_get_subjectCN()
    - wolfSSL_X509_get_next_altname()
    - wolfSSL_X509_get_der()
- Modify SSLSocket class to override 'object' instead of socket class.  Fixes issue with Python 2.7 not able to override some socket class functions.
- Correctly free memory for WOLFSSL session
- Improve side detection in some cases
- Add USE_LOCAL_WOLFSSL environment variable for compiling against local native wolfSSL libraries. Necessary for building against FIPS 140-2 library.
- Switch setup.py to use install_requires[] and test_requires[]
- Update copyrights to 2019
- Update README notes