### PR TITLE
Build Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,10 +64,7 @@ target/
 .python-version
 
 # pyenv dist build
-venv_2.7
-venv_3.4
-venv_3.5
-venv_3.6
+venv_*
 
 # code editor preferences
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       script:
         - ./make/manylinux1/build_wheels.sh
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode8.3
       script:
         - ./make/osx/build_wheels.sh
 

--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -1,30 +1,29 @@
 set -e
 set +x
 
-for PYVERSION in 2.7 3.4 3.5 3.6; do
-    PYTHONBIN=/Library/Frameworks/Python.framework/Versions/${PYVERSION}/bin
-    PYTHONEXE=${PYTHONBIN}/python${PYVERSION}
-    export PATH="${PYTHONBIN}":$PATH
+for VER in 2.7 3.4 3.5 3.6 3.7; do
+    PYTHON=python${VER}
+    PIP=pip${VER}
+    VENV=venv_${VER}
 
     # update pip for newer TLS support
-    curl https://bootstrap.pypa.io/get-pip.py | ${PYTHONEXE}
-    "${PYTHONBIN}/pip" install --upgrade pip
+    curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON}
+    ${PIP} install --upgrade pip
 
     # update virtualenv
-    ${PYTHONEXE} -m pip install virtualenv
-
-    virtualenv -p ${PYTHONEXE} venv_${PYVERSION}
-    . ./venv_${PYVERSION}/bin/activate
+    ${PIP} install --upgrade virtualenv
+    virtualenv -p ${PYTHON} ${VENV}
+    . ./${VENV}/bin/activate
 
     # install cffi module
-    ${PYTHONEXE} -m pip install cffi
+    ${PYTHON} -m pip install cffi
 
-    ${PYTHONEXE} setup.py bdist_wheel
-    "${PYTHONBIN}/pip" install -r requirements/test.txt
+    ${PYTHON} setup.py bdist_wheel
+    ${PIP} install -r requirements/test.txt
     set +e
-    "${PYTHONBIN}/pip" uninstall -y wolfssl
+    ${PIP} uninstall -y wolfssl
     set -e
-    "${PYTHONBIN}/pip" install wolfssl --no-index -f dist
+    ${PIP} install wolfssl --no-index -f dist
     rm -rf tests/__pycache__
     py.test tests
     deactivate

--- a/make/osx/build_wheels.sh
+++ b/make/osx/build_wheels.sh
@@ -2,21 +2,18 @@ set -e
 set +x
 
 for VER in 2.7 3.4 3.5 3.6 3.7; do
-    PYTHON=python${VER}
-    PIP=pip${VER}
-    VENV=venv_${VER}
+    PIP="pip${VER}"
+    PYTHON="python${VER}"
+    VENV="venv_${VER}"
 
     # update pip for newer TLS support
     curl https://bootstrap.pypa.io/get-pip.py | ${PYTHON}
-    ${PIP} install --upgrade pip
+    ${PIP} install -r requirements/setup.txt
 
     # update virtualenv
     ${PIP} install --upgrade virtualenv
     virtualenv -p ${PYTHON} ${VENV}
     . ./${VENV}/bin/activate
-
-    # install cffi module
-    ${PYTHON} -m pip install cffi
 
     ${PYTHON} setup.py bdist_wheel
     ${PIP} install -r requirements/test.txt


### PR DESCRIPTION
1. Replaced the versioned venv paths in gitignore with a wildcard, like in the wolfCrypt project.
2. Remove the absolute path to the python interpreter. They just need to be in the path. (For example, you might install old versions in /opt and add their subdirs to the path while the latest runs out of its location.)