### PR TITLE
Add support for wolfSSL Context password callback

### DIFF
--- a/src/wolfssl/_build_ffi.py
+++ b/src/wolfssl/_build_ffi.py
@@ -61,6 +61,7 @@ ffi.cdef(
     typedef unsigned char byte;
     typedef unsigned int word32;
 
+    typedef int pem_password_cb(char* passwd, int sz, int rw, void* userdata);
     /**
      * Memory free function
      */
@@ -99,6 +100,7 @@ ffi.cdef(
     int  wolfSSL_CTX_UseSNI(void*, unsigned char, const void*, unsigned short);
     long wolfSSL_CTX_get_options(void*);
     long wolfSSL_CTX_set_options(void*, long);
+    void wolfSSL_CTX_set_default_passwd_cb(void*, pem_password_cb*);
 
     /**
      * SSL/TLS Session functions


### PR DESCRIPTION
This PR adds support to register a default password callback.  

The load_cert_chain() python API can now accept the password parameter encoded using UTF-8. 

You can use the set_passwd_cb() python API to register a callback function that sets the password before loading an encrypted key using a call to  load_cert_chain().

The builder script has been updated to include wolfSSL_CTX_set_default_passwd_cb() wolfSSL API.

This password callback feature allows urllib3 tests in https://github.com/wolfSSL/osp/pull/36 to work:
```
TestHTTPS::test_client_key_password
TestHTTPS_TLSv1::test_client_key_password
TestClientCerts::test_client_cert_with_string_password
TestClientCerts::test_client_cert_with_bytes_password
TestClientCerts::test_load_keyfile_with_invalid_password
```

Here's an example of how to use it:
```
    def load_cert_chain(self, certfile, keyfile=None, password=None):
        if password is not None:
            if not isinstance(password, six.binary_type):
                password = password.encode("utf-8")
            self._ctx.set_passwd_cb(lambda *_: password)
        self._ctx.load_cert_chain(certfile, keyfile=keyfile, password=password)
```



