### PR TITLE
update example certs to match main wolfSSL ones

### DIFF
--- a/certs/ca-cert.pem
+++ b/certs/ca-cert.pem
@@ -1,13 +1,12 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number:
-            b7:b6:90:33:66:1b:6b:23
+        Serial Number: 12309252214903945037 (0xaad33fac180a374d)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Feb 10 19:49:52 2021 GMT
+            Not After : Nov  7 19:49:52 2023 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -38,32 +37,36 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B7:B6:90:33:66:1B:6B:23
+                serial:AA:D3:3F:AC:18:0A:37:4D
 
             X509v3 Basic Constraints: 
                 CA:TRUE
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, IP Address:127.0.0.1
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         0e:93:48:44:4a:72:96:60:71:25:82:a9:2c:ca:60:5b:f2:88:
-         3e:cf:11:74:5a:11:4a:dc:d9:d8:f6:58:2c:05:d3:56:d9:e9:
-         8f:37:ef:8e:3e:3b:ff:22:36:00:ca:d8:e2:96:3f:a7:d1:ed:
-         1f:de:7a:b0:d7:8f:36:bd:41:55:1e:d4:b9:86:3b:87:25:69:
-         35:60:48:d6:e4:5a:94:ce:a2:fa:70:38:36:c4:85:b4:4b:23:
-         fe:71:9e:2f:db:06:c7:b5:9c:21:f0:3e:7c:eb:91:f8:5c:09:
-         fd:84:43:a4:b3:4e:04:0c:22:31:71:6a:48:c8:ab:bb:e8:ce:
-         fa:67:15:1a:3a:82:98:43:33:b5:0e:1f:1e:89:f8:37:de:1b:
-         e6:b5:a0:f4:a2:8b:b7:1c:90:ba:98:6d:94:21:08:80:5d:f3:
-         bf:66:ad:c9:72:28:7a:6a:48:ee:cf:63:69:31:8c:c5:8e:66:
-         da:4b:78:65:e8:03:3a:4b:f8:cc:42:54:d3:52:5c:2d:04:ae:
-         26:87:e1:7e:40:cb:45:41:16:4b:6e:a3:2e:4a:76:bd:29:7f:
-         1c:53:37:06:ad:e9:5b:6a:d6:b7:4e:94:a2:7c:e8:ac:4e:a6:
-         50:3e:2b:32:9e:68:42:1b:e4:59:67:61:ea:c7:9a:51:9c:1c:
-         55:a3:77:76
+         62:98:c8:58:cf:56:03:86:5b:1b:71:49:7d:05:03:5d:e0:08:
+         86:ad:db:4a:de:ab:22:96:a8:c3:59:68:c1:37:90:40:df:bd:
+         89:d0:bc:da:8e:ef:87:b2:c2:62:52:e1:1a:29:17:6a:96:99:
+         c8:4e:d8:32:fe:b8:d1:5c:3b:0a:c2:3c:5f:a1:1e:98:7f:ce:
+         89:26:21:1f:64:9c:15:7a:9c:ef:fb:1d:85:6a:fa:98:ce:a8:
+         a9:ab:c3:a2:c0:eb:87:ed:bc:21:df:f3:07:5b:ae:fd:40:d4:
+         ae:20:d0:76:8a:31:0a:a2:62:7c:61:0d:ce:5d:9a:1e:e4:20:
+         88:51:49:fb:77:a9:cd:4d:c6:bf:54:99:33:ef:4b:a0:73:70:
+         6d:2e:d9:3d:08:f6:12:39:31:68:c6:61:5c:41:b5:1b:f4:38:
+         7d:fc:be:73:66:2d:f7:ca:5b:2c:5b:31:aa:cf:f6:7f:30:e4:
+         12:2c:8e:d6:38:51:e6:45:ee:d5:da:c3:83:d6:ed:5e:ec:d6:
+         b6:14:b3:93:59:e1:55:4a:7f:04:df:ce:65:d4:df:18:4f:dd:
+         b4:45:7f:a6:56:30:c4:05:44:98:9d:4f:26:6d:84:80:a0:5e:
+         ed:23:d1:48:87:0e:05:06:91:3b:b0:3c:bb:8c:8f:3c:7b:4c:
+         4f:a1:ca:98
 -----BEGIN CERTIFICATE-----
-MIIEqjCCA5KgAwIBAgIJALe2kDNmG2sjMA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
+MIIE6TCCA9GgAwIBAgIJAKrTP6wYCjdNMA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTAe
-Fw0xNjA4MTEyMDA3MzdaFw0xOTA1MDgyMDA3MzdaMIGUMQswCQYDVQQGEwJVUzEQ
+Fw0yMTAyMTAxOTQ5NTJaFw0yMzExMDcxOTQ5NTJaMIGUMQswCQYDVQQGEwJVUzEQ
 MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
 dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
 LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZI
@@ -72,16 +75,18 @@ mNOs3gNm7irx2LB9bgdUCxCYIU2AyxIg58xP3kV9yXJ3MurKkLtpUhADL6jzlcXx
 i2JWG+9nb6QQQZWtCpvjpcCw0nB2UDBbqOgILHztp6J6jTgpHKzH7fJ8lbCVgn1J
 XDjNdyXvvYB1U5Q8PcpjW58VtdMdEy8Z0TzbdjrMuH3J5cLX2kBv2CHccxtCLVOc
 /hr8fat6Nj+Y3oR8BWfOahQ4h6nxjLVoy2h/cSAr9aBj9VYvoybSt2+xWhfXOJkI
-/pNYb/7DE0kIFgunTWcAUjFnI06Y7VFFHbkE2Qvs2CizS73tNnkCAwEAAaOB/DCB
-+TAdBgNVHQ4EFgQUJ45nEXTDJh0/7TNjs6TYHTDl6NUwgckGA1UdIwSBwTCBvoAU
-J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
-VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
-aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
-MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDAYD
-VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEADpNIREpylmBxJYKpLMpgW/KI
-Ps8RdFoRStzZ2PZYLAXTVtnpjzfvjj47/yI2AMrY4pY/p9HtH956sNePNr1BVR7U
-uYY7hyVpNWBI1uRalM6i+nA4NsSFtEsj/nGeL9sGx7WcIfA+fOuR+FwJ/YRDpLNO
-BAwiMXFqSMiru+jO+mcVGjqCmEMztQ4fHon4N94b5rWg9KKLtxyQuphtlCEIgF3z
-v2atyXIoempI7s9jaTGMxY5m2kt4ZegDOkv4zEJU01JcLQSuJofhfkDLRUEWS26j
-Lkp2vSl/HFM3Bq3pW2rWt06UonzorE6mUD4rMp5oQhvkWWdh6seaUZwcVaN3dg==
+/pNYb/7DE0kIFgunTWcAUjFnI06Y7VFFHbkE2Qvs2CizS73tNnkCAwEAAaOCATow
+ggE2MB0GA1UdDgQWBBQnjmcRdMMmHT/tM2OzpNgdMOXo1TCByQYDVR0jBIHBMIG+
+gBQnjmcRdMMmHT/tM2OzpNgdMOXo1aGBmqSBlzCBlDELMAkGA1UEBhMCVVMxEDAO
+BgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rv
+b3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5j
+b20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CCQCq0z+sGAo3TTAM
+BgNVHRMEBTADAQH/MBwGA1UdEQQVMBOCC2V4YW1wbGUuY29thwR/AAABMB0GA1Ud
+JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEAYpjI
+WM9WA4ZbG3FJfQUDXeAIhq3bSt6rIpaow1lowTeQQN+9idC82o7vh7LCYlLhGikX
+apaZyE7YMv640Vw7CsI8X6EemH/OiSYhH2ScFXqc7/sdhWr6mM6oqavDosDrh+28
+Id/zB1uu/UDUriDQdooxCqJifGENzl2aHuQgiFFJ+3epzU3Gv1SZM+9LoHNwbS7Z
+PQj2EjkxaMZhXEG1G/Q4ffy+c2Yt98pbLFsxqs/2fzDkEiyO1jhR5kXu1drDg9bt
+XuzWthSzk1nhVUp/BN/OZdTfGE/dtEV/plYwxAVEmJ1PJm2EgKBe7SPRSIcOBQaR
+O7A8u4yPPHtMT6HKmA==
 -----END CERTIFICATE-----

--- a/certs/client-cert.pem
+++ b/certs/client-cert.pem
@@ -1,13 +1,12 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number:
-            b9:bc:90:ed:ad:aa:0a:8c
+        Serial Number: 17391944375755183620 (0xf15c9943663d9604)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=wolfSSL_2048, OU=Programming-2048, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Feb 10 19:49:52 2021 GMT
+            Not After : Nov  7 19:49:52 2023 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL_2048, OU=Programming-2048, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -38,32 +37,36 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:33:D8:45:66:D7:68:87:18:7E:54:0D:70:27:91:C7:26:D7:85:65:C0
                 DirName:/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B9:BC:90:ED:AD:AA:0A:8C
+                serial:F1:5C:99:43:66:3D:96:04
 
             X509v3 Basic Constraints: 
                 CA:TRUE
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, IP Address:127.0.0.1
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         33:85:08:b4:58:0e:a2:00:03:74:de:77:fb:d1:2b:76:9c:97:
-         90:20:21:a2:e8:2e:22:50:26:04:76:ba:5b:47:79:e5:52:f7:
-         c4:0d:79:ff:62:3f:05:7c:c3:08:6c:e0:b7:81:d0:ce:c6:c9:
-         46:b9:8e:4b:5f:56:79:4b:13:b6:d1:6b:66:4b:ce:00:0d:e3:
-         76:5e:fb:cb:b5:5d:12:31:05:f1:bb:39:f6:86:90:ca:92:56:
-         a4:a0:75:21:b6:1d:4c:96:c3:45:eb:5a:91:94:32:d3:59:b8:
-         c9:73:1f:03:a9:81:63:e0:43:c0:1e:c8:65:be:3b:a7:53:c3:
-         44:ff:b3:fb:47:84:a8:b6:9d:00:d5:6b:ae:87:f8:bb:35:b2:
-         6c:66:0b:11:ee:6f:fe:12:ed:59:79:f1:3e:f2:d3:61:27:8b:
-         95:7e:99:75:8d:a4:9f:34:85:f1:25:4d:48:1e:9b:6b:70:f6:
-         66:cc:56:b1:a3:02:52:8a:7c:aa:af:07:da:97:c6:0c:a5:8f:
-         ed:cb:f5:d8:04:5d:97:0a:5d:5a:2b:49:f5:bd:93:e5:23:9b:
-         99:b5:0c:ff:0c:7e:38:82:b2:6e:ab:8a:c9:a7:45:ab:d6:d7:
-         93:35:70:07:7e:c8:3d:a5:fe:33:8f:d9:85:c0:c7:5a:02:e4:
-         7c:d6:35:9e
+         ba:2b:48:d1:a8:e3:c2:84:42:96:a1:7c:e5:f1:46:ba:4c:f7:
+         87:57:c7:78:c8:c1:32:c4:69:ff:85:bb:5d:6a:dd:c9:87:7e:
+         fe:bb:f4:fd:15:0a:4c:94:95:80:30:90:45:03:f8:33:87:ca:
+         5f:74:38:a4:d0:5a:c7:65:38:c3:b0:e8:87:b1:49:32:b9:ac:
+         e9:fb:d3:08:1d:a4:51:7b:d7:d9:4b:79:35:a2:3a:0b:e4:0c:
+         a0:02:9c:a1:68:e1:5d:6c:8e:2e:3a:24:de:bb:d6:1c:a7:ac:
+         2e:cd:57:44:48:f6:72:e0:c7:5b:93:dc:7d:5b:64:0e:17:84:
+         68:2c:95:1d:2c:86:d6:b0:74:67:51:6e:7b:f4:d5:61:38:51:
+         b3:18:e3:10:16:73:4b:36:8a:8a:62:05:f5:56:8a:be:21:e1:
+         78:7d:bf:ad:45:f9:0b:f5:af:a0:62:01:fd:3f:49:df:39:3c:
+         ff:46:e8:0a:fe:5c:6b:bb:41:a5:64:f1:5c:9b:51:4c:bc:6d:
+         9f:a3:20:ed:e9:48:e1:a9:be:08:2d:85:42:59:d6:43:7d:47:
+         22:a5:fa:1f:a2:58:76:0b:70:1c:1d:59:1d:aa:be:5d:2d:25:
+         7c:b1:06:b6:c0:aa:28:aa:93:7c:d0:bd:43:ad:91:50:1c:7b:
+         4d:f3:e4:d7
 -----BEGIN CERTIFICATE-----
-MIIEyjCCA7KgAwIBAgIJALm8kO2tqgqMMA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
+MIIFBzCCA++gAwIBAgIJAPFcmUNmPZYEMA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjEVMBMG
 A1UECgwMd29sZlNTTF8yMDQ4MRkwFwYDVQQLDBBQcm9ncmFtbWluZy0yMDQ4MRgw
 FgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29s
-ZnNzbC5jb20wHhcNMTYwODExMjAwNzM3WhcNMTkwNTA4MjAwNzM3WjCBnjELMAkG
+ZnNzbC5jb20wHhcNMjEwMjEwMTk0OTUyWhcNMjMxMTA3MTk0OTUyWjCBnjELMAkG
 A1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xFTAT
 BgNVBAoMDHdvbGZTU0xfMjA0ODEZMBcGA1UECwwQUHJvZ3JhbW1pbmctMjA0ODEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
@@ -73,16 +76,17 @@ StIb94u6zw357+zxgR57mwNHmr9lzH9lJGmm6BSJW+Q098WwFJP1Z3s6enjhAVZW
 kaYTQo3SPECcTO/Rht83URsMoTv18aNKNeThzpbfG36/TpfQEOioCDCBryALQxTF
 dGe0MoJvjYbCiECZNoO6HkByIhfXUmUkc7DO7xnNrv94bHvAEgPUTnINUG07ozuj
 mV6dyNkMhbPZitlUJttt+qy7/yVMxNF59HHThkAYE7BjtXJOMMSXhIYtVi/XFfd/
-wK71/Fvl+6G60wIDAQABo4IBBzCCAQMwHQYDVR0OBBYEFDPYRWbXaIcYflQNcCeR
+wK71/Fvl+6G60wIDAQABo4IBRDCCAUAwHQYDVR0OBBYEFDPYRWbXaIcYflQNcCeR
 xybXhWXAMIHTBgNVHSMEgcswgciAFDPYRWbXaIcYflQNcCeRxybXhWXAoYGkpIGh
 MIGeMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96
 ZW1hbjEVMBMGA1UECgwMd29sZlNTTF8yMDQ4MRkwFwYDVQQLDBBQcm9ncmFtbWlu
 Zy0yMDQ4MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEW
-EGluZm9Ad29sZnNzbC5jb22CCQC5vJDtraoKjDAMBgNVHRMEBTADAQH/MA0GCSqG
-SIb3DQEBCwUAA4IBAQAzhQi0WA6iAAN03nf70St2nJeQICGi6C4iUCYEdrpbR3nl
-UvfEDXn/Yj8FfMMIbOC3gdDOxslGuY5LX1Z5SxO20WtmS84ADeN2XvvLtV0SMQXx
-uzn2hpDKklakoHUhth1MlsNF61qRlDLTWbjJcx8DqYFj4EPAHshlvjunU8NE/7P7
-R4Sotp0A1Wuuh/i7NbJsZgsR7m/+Eu1ZefE+8tNhJ4uVfpl1jaSfNIXxJU1IHptr
-cPZmzFaxowJSinyqrwfal8YMpY/ty/XYBF2XCl1aK0n1vZPlI5uZtQz/DH44grJu
-q4rJp0Wr1teTNXAHfsg9pf4zj9mFwMdaAuR81jWe
+EGluZm9Ad29sZnNzbC5jb22CCQDxXJlDZj2WBDAMBgNVHRMEBTADAQH/MBwGA1Ud
+EQQVMBOCC2V4YW1wbGUuY29thwR/AAABMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEAuitI0ajjwoRClqF85fFGukz3h1fH
+eMjBMsRp/4W7XWrdyYd+/rv0/RUKTJSVgDCQRQP4M4fKX3Q4pNBax2U4w7Doh7FJ
+Mrms6fvTCB2kUXvX2Ut5NaI6C+QMoAKcoWjhXWyOLjok3rvWHKesLs1XREj2cuDH
+W5PcfVtkDheEaCyVHSyG1rB0Z1Fue/TVYThRsxjjEBZzSzaKimIF9VaKviHheH2/
+rUX5C/WvoGIB/T9J3zk8/0boCv5ca7tBpWTxXJtRTLxtn6Mg7elI4am+CC2FQlnW
+Q31HIqX6H6JYdgtwHB1ZHaq+XS0lfLEGtsCqKKqTfNC9Q62RUBx7TfPk1w==
 -----END CERTIFICATE-----

--- a/certs/server-cert.pem
+++ b/certs/server-cert.pem
@@ -5,8 +5,8 @@ Certificate:
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Feb 10 19:49:53 2021 GMT
+            Not After : Nov  7 19:49:53 2023 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL, OU=Support, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -37,32 +37,36 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B7:B6:90:33:66:1B:6B:23
+                serial:AA:D3:3F:AC:18:0A:37:4D
 
             X509v3 Basic Constraints: 
                 CA:TRUE
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, IP Address:127.0.0.1
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         51:fe:2a:df:07:7e:43:ca:66:8d:15:c4:2b:db:57:b2:06:6d:
-         0d:90:66:ff:a5:24:9c:14:ef:81:f2:a4:ab:99:a9:6a:49:20:
-         a5:d2:71:e7:1c:3c:99:07:c7:47:fc:e8:96:b4:f5:42:30:ce:
-         39:01:4b:d1:c2:e8:bc:95:84:87:ce:55:5d:97:9f:cf:78:f3:
-         56:9b:a5:08:6d:ac:f6:a5:5c:c4:ef:3e:2a:39:a6:48:26:29:
-         7b:2d:e0:cd:a6:8c:57:48:0b:bb:31:32:c2:bf:d9:43:4c:47:
-         25:18:81:a8:c9:33:82:41:9b:ba:61:86:d7:84:93:17:24:25:
-         36:ca:4d:63:6b:4f:95:79:d8:60:e0:1e:f5:ac:c1:8a:a1:b1:
-         7e:85:8e:87:20:2f:08:31:ad:5e:c6:4a:c8:61:f4:9e:07:1e:
-         a2:22:ed:73:7c:85:ee:fa:62:dc:50:36:aa:fd:c7:9d:aa:18:
-         04:fb:ea:cc:2c:68:9b:b3:a9:c2:96:d8:c1:cc:5a:7e:f7:0d:
-         9e:08:e0:9d:29:8b:84:46:8f:d3:91:6a:b5:b8:7a:5c:cc:4f:
-         55:01:b8:9a:48:a0:94:43:ca:25:47:52:0a:f7:f4:be:b0:d1:
-         71:6d:a5:52:4a:65:50:b2:ad:4e:1d:e0:6c:01:d8:fb:43:80:
-         e6:e4:0c:37
+         1b:0d:a6:44:93:0d:0e:0c:35:28:26:40:31:d2:eb:26:4c:47:
+         5b:19:fb:ad:fe:3a:f5:30:3a:28:d7:aa:69:a4:15:e7:26:6e:
+         b7:33:56:ac:8f:34:3d:f3:21:2f:53:58:91:d0:3e:b4:39:48:
+         bf:93:11:74:36:d3:87:49:c3:34:0d:30:30:ab:f4:4c:27:19:
+         d5:c4:0c:ad:49:bd:91:f8:da:9e:c8:2d:2a:ac:e2:75:8e:aa:
+         08:d9:bf:65:ff:a3:b1:4f:f0:60:6f:4d:95:c4:06:7f:af:66:
+         6a:23:3b:3a:a4:61:b6:6c:ca:be:e1:b0:77:f3:ec:83:d5:8c:
+         1d:85:7f:8d:74:c8:ec:1e:49:ec:57:4a:cc:fd:e2:3a:3e:54:
+         50:ae:67:cd:17:b0:67:a5:53:7f:c3:0e:3e:a7:58:e8:df:d5:
+         0c:f2:64:f3:ad:12:70:e3:b9:42:bc:08:60:76:d5:0c:a5:31:
+         77:50:e0:c8:f3:3a:3d:45:cf:32:75:ef:10:dd:b5:ed:6e:d2:
+         2d:57:82:95:38:bc:7d:54:c4:84:5e:fb:7e:83:f5:f1:2d:9c:
+         98:ac:73:e3:a7:d2:02:30:d6:1f:06:1e:d0:dc:3a:ac:f4:c2:
+         c2:be:72:40:9a:ea:cf:35:21:3b:56:6d:e1:52:f2:80:d7:35:
+         83:97:07:cc
 -----BEGIN CERTIFICATE-----
-MIIEnjCCA4agAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMx
+MIIE3TCCA8WgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMx
 EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
 d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
-bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwODEx
-MjAwNzM3WhcNMTkwNTA4MjAwNzM3WjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMjEwMjEw
+MTk0OTUzWhcNMjMxMTA3MTk0OTUzWjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
 B01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xEDAOBgNVBAoMB3dvbGZTU0wxEDAO
 BgNVBAsMB1N1cHBvcnQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
 SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
@@ -71,29 +75,30 @@ f/5cnFF194rKB+c1L4/hvXvAL3yrZKgX/Mpde7rgIeVyLm8uhtiVc9qsG1O5Xz/X
 GQ0lT+FjY1GLC2Q/rUO4pRxcNLOuAKBjxfZ/C1loeHOmjBipAm2vwxkBLrgQ48bM
 QLRpo0YzaYduxLsXpvPo3a1zvHsvIbX9ZlEMvVSz4W1fHLwjc9EJA4kU0hC5ZMMq
 0KGWSrzh1Bpbx6DAwWN4D0Q3MDKWgDIjlaF3uhPSl3PiXSXJag3DOWCktLBpQkIJ
-6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOB/DCB+TAdBgNVHQ4EFgQU
-sxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAUJ45nEXTDJh0/7TNj
-s6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5h
-MRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwK
-Q29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcN
-AQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDAYDVR0TBAUwAwEB/zAN
-BgkqhkiG9w0BAQsFAAOCAQEAUf4q3wd+Q8pmjRXEK9tXsgZtDZBm/6UknBTvgfKk
-q5mpakkgpdJx5xw8mQfHR/zolrT1QjDOOQFL0cLovJWEh85VXZefz3jzVpulCG2s
-9qVcxO8+KjmmSCYpey3gzaaMV0gLuzEywr/ZQ0xHJRiBqMkzgkGbumGG14STFyQl
-NspNY2tPlXnYYOAe9azBiqGxfoWOhyAvCDGtXsZKyGH0ngceoiLtc3yF7vpi3FA2
-qv3HnaoYBPvqzCxom7OpwpbYwcxafvcNngjgnSmLhEaP05Fqtbh6XMxPVQG4mkig
-lEPKJUdSCvf0vrDRcW2lUkplULKtTh3gbAHY+0OA5uQMNw==
+6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOCATowggE2MB0GA1UdDgQW
+BBSzETLJkpiE4sn40DtuA0LKHw6OPDCByQYDVR0jBIHBMIG+gBQnjmcRdMMmHT/t
+M2OzpNgdMOXo1aGBmqSBlzCBlDELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRh
+bmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRMwEQYDVQQL
+DApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG
+9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CCQCq0z+sGAo3TTAMBgNVHRMEBTADAQH/
+MBwGA1UdEQQVMBOCC2V4YW1wbGUuY29thwR/AAABMB0GA1UdJQQWMBQGCCsGAQUF
+BwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEAGw2mRJMNDgw1KCZAMdLr
+JkxHWxn7rf469TA6KNeqaaQV5yZutzNWrI80PfMhL1NYkdA+tDlIv5MRdDbTh0nD
+NA0wMKv0TCcZ1cQMrUm9kfjansgtKqzidY6qCNm/Zf+jsU/wYG9NlcQGf69maiM7
+OqRhtmzKvuGwd/Psg9WMHYV/jXTI7B5J7FdKzP3iOj5UUK5nzRewZ6VTf8MOPqdY
+6N/VDPJk860ScOO5QrwIYHbVDKUxd1DgyPM6PUXPMnXvEN217W7SLVeClTi8fVTE
+hF77foP18S2cmKxz46fSAjDWHwYe0Nw6rPTCwr5yQJrqzzUhO1Zt4VLygNc1g5cH
+zA==
 -----END CERTIFICATE-----
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number:
-            b7:b6:90:33:66:1b:6b:23
+        Serial Number: 12309252214903945037 (0xaad33fac180a374d)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: Aug 11 20:07:37 2016 GMT
-            Not After : May  8 20:07:37 2019 GMT
+            Not Before: Feb 10 19:49:52 2021 GMT
+            Not After : Nov  7 19:49:52 2023 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -124,32 +129,36 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:B7:B6:90:33:66:1B:6B:23
+                serial:AA:D3:3F:AC:18:0A:37:4D
 
             X509v3 Basic Constraints: 
                 CA:TRUE
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, IP Address:127.0.0.1
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         0e:93:48:44:4a:72:96:60:71:25:82:a9:2c:ca:60:5b:f2:88:
-         3e:cf:11:74:5a:11:4a:dc:d9:d8:f6:58:2c:05:d3:56:d9:e9:
-         8f:37:ef:8e:3e:3b:ff:22:36:00:ca:d8:e2:96:3f:a7:d1:ed:
-         1f:de:7a:b0:d7:8f:36:bd:41:55:1e:d4:b9:86:3b:87:25:69:
-         35:60:48:d6:e4:5a:94:ce:a2:fa:70:38:36:c4:85:b4:4b:23:
-         fe:71:9e:2f:db:06:c7:b5:9c:21:f0:3e:7c:eb:91:f8:5c:09:
-         fd:84:43:a4:b3:4e:04:0c:22:31:71:6a:48:c8:ab:bb:e8:ce:
-         fa:67:15:1a:3a:82:98:43:33:b5:0e:1f:1e:89:f8:37:de:1b:
-         e6:b5:a0:f4:a2:8b:b7:1c:90:ba:98:6d:94:21:08:80:5d:f3:
-         bf:66:ad:c9:72:28:7a:6a:48:ee:cf:63:69:31:8c:c5:8e:66:
-         da:4b:78:65:e8:03:3a:4b:f8:cc:42:54:d3:52:5c:2d:04:ae:
-         26:87:e1:7e:40:cb:45:41:16:4b:6e:a3:2e:4a:76:bd:29:7f:
-         1c:53:37:06:ad:e9:5b:6a:d6:b7:4e:94:a2:7c:e8:ac:4e:a6:
-         50:3e:2b:32:9e:68:42:1b:e4:59:67:61:ea:c7:9a:51:9c:1c:
-         55:a3:77:76
+         62:98:c8:58:cf:56:03:86:5b:1b:71:49:7d:05:03:5d:e0:08:
+         86:ad:db:4a:de:ab:22:96:a8:c3:59:68:c1:37:90:40:df:bd:
+         89:d0:bc:da:8e:ef:87:b2:c2:62:52:e1:1a:29:17:6a:96:99:
+         c8:4e:d8:32:fe:b8:d1:5c:3b:0a:c2:3c:5f:a1:1e:98:7f:ce:
+         89:26:21:1f:64:9c:15:7a:9c:ef:fb:1d:85:6a:fa:98:ce:a8:
+         a9:ab:c3:a2:c0:eb:87:ed:bc:21:df:f3:07:5b:ae:fd:40:d4:
+         ae:20:d0:76:8a:31:0a:a2:62:7c:61:0d:ce:5d:9a:1e:e4:20:
+         88:51:49:fb:77:a9:cd:4d:c6:bf:54:99:33:ef:4b:a0:73:70:
+         6d:2e:d9:3d:08:f6:12:39:31:68:c6:61:5c:41:b5:1b:f4:38:
+         7d:fc:be:73:66:2d:f7:ca:5b:2c:5b:31:aa:cf:f6:7f:30:e4:
+         12:2c:8e:d6:38:51:e6:45:ee:d5:da:c3:83:d6:ed:5e:ec:d6:
+         b6:14:b3:93:59:e1:55:4a:7f:04:df:ce:65:d4:df:18:4f:dd:
+         b4:45:7f:a6:56:30:c4:05:44:98:9d:4f:26:6d:84:80:a0:5e:
+         ed:23:d1:48:87:0e:05:06:91:3b:b0:3c:bb:8c:8f:3c:7b:4c:
+         4f:a1:ca:98
 -----BEGIN CERTIFICATE-----
-MIIEqjCCA5KgAwIBAgIJALe2kDNmG2sjMA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
+MIIE6TCCA9GgAwIBAgIJAKrTP6wYCjdNMA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTAe
-Fw0xNjA4MTEyMDA3MzdaFw0xOTA1MDgyMDA3MzdaMIGUMQswCQYDVQQGEwJVUzEQ
+Fw0yMTAyMTAxOTQ5NTJaFw0yMzExMDcxOTQ5NTJaMIGUMQswCQYDVQQGEwJVUzEQ
 MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
 dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
 LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZI
@@ -158,16 +167,18 @@ mNOs3gNm7irx2LB9bgdUCxCYIU2AyxIg58xP3kV9yXJ3MurKkLtpUhADL6jzlcXx
 i2JWG+9nb6QQQZWtCpvjpcCw0nB2UDBbqOgILHztp6J6jTgpHKzH7fJ8lbCVgn1J
 XDjNdyXvvYB1U5Q8PcpjW58VtdMdEy8Z0TzbdjrMuH3J5cLX2kBv2CHccxtCLVOc
 /hr8fat6Nj+Y3oR8BWfOahQ4h6nxjLVoy2h/cSAr9aBj9VYvoybSt2+xWhfXOJkI
-/pNYb/7DE0kIFgunTWcAUjFnI06Y7VFFHbkE2Qvs2CizS73tNnkCAwEAAaOB/DCB
-+TAdBgNVHQ4EFgQUJ45nEXTDJh0/7TNjs6TYHTDl6NUwgckGA1UdIwSBwTCBvoAU
-J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
-VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
-aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
-MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDAYD
-VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEADpNIREpylmBxJYKpLMpgW/KI
-Ps8RdFoRStzZ2PZYLAXTVtnpjzfvjj47/yI2AMrY4pY/p9HtH956sNePNr1BVR7U
-uYY7hyVpNWBI1uRalM6i+nA4NsSFtEsj/nGeL9sGx7WcIfA+fOuR+FwJ/YRDpLNO
-BAwiMXFqSMiru+jO+mcVGjqCmEMztQ4fHon4N94b5rWg9KKLtxyQuphtlCEIgF3z
-v2atyXIoempI7s9jaTGMxY5m2kt4ZegDOkv4zEJU01JcLQSuJofhfkDLRUEWS26j
-Lkp2vSl/HFM3Bq3pW2rWt06UonzorE6mUD4rMp5oQhvkWWdh6seaUZwcVaN3dg==
+/pNYb/7DE0kIFgunTWcAUjFnI06Y7VFFHbkE2Qvs2CizS73tNnkCAwEAAaOCATow
+ggE2MB0GA1UdDgQWBBQnjmcRdMMmHT/tM2OzpNgdMOXo1TCByQYDVR0jBIHBMIG+
+gBQnjmcRdMMmHT/tM2OzpNgdMOXo1aGBmqSBlzCBlDELMAkGA1UEBhMCVVMxEDAO
+BgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rv
+b3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5j
+b20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CCQCq0z+sGAo3TTAM
+BgNVHRMEBTADAQH/MBwGA1UdEQQVMBOCC2V4YW1wbGUuY29thwR/AAABMB0GA1Ud
+JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEAYpjI
+WM9WA4ZbG3FJfQUDXeAIhq3bSt6rIpaow1lowTeQQN+9idC82o7vh7LCYlLhGikX
+apaZyE7YMv640Vw7CsI8X6EemH/OiSYhH2ScFXqc7/sdhWr6mM6oqavDosDrh+28
+Id/zB1uu/UDUriDQdooxCqJifGENzl2aHuQgiFFJ+3epzU3Gv1SZM+9LoHNwbS7Z
+PQj2EjkxaMZhXEG1G/Q4ffy+c2Yt98pbLFsxqs/2fzDkEiyO1jhR5kXu1drDg9bt
+XuzWthSzk1nhVUp/BN/OZdTfGE/dtEV/plYwxAVEmJ1PJm2EgKBe7SPRSIcOBQaR
+O7A8u4yPPHtMT6HKmA==
 -----END CERTIFICATE-----


### PR DESCRIPTION
Some certs in the "certs" directory had expired, updating them to match main wolfSSL ones here.