### PR TITLE
Improve make_optional_func_list and make renegotiation functions optional.

### DIFF
--- a/src/wolfssl/_openssl.py
+++ b/src/wolfssl/_openssl.py
@@ -230,7 +230,6 @@ def construct_cdef(optional_funcs):
         X509*         SSL_get_peer_certificate(SSL*);
         const char*   SSL_alert_type_string_long(int);
         const char*   SSL_alert_desc_string_long(int);
-        int           SSL_renegotiate(SSL*);
         void          SSL_get0_next_proto_negotiated(const SSL*,
                           const unsigned char**, unsigned*);
         const char*   SSL_get_servername(SSL*, unsigned char);


### PR DESCRIPTION
`make_optional_func_list` will fall back to using `nm` to determine if a
function is provided by libwolfssl if libwolfssl is a static library. This
commit makes it so we first check if `nm` is available. If it's not available,
the function will print a warning and assume all optional functions are
available.