### PR TITLE
Fix alert history code.

### DIFF
--- a/wolfssl/_build_ffi.py
+++ b/wolfssl/_build_ffi.py
@@ -325,12 +325,12 @@ ffi.set_source(
 )
 
 cdef = """
-    /**
+    /*
      * Constants
      */
     static const long SOCKET_PEER_CLOSED_E;
 
-    /**
+    /*
      * Types
      */
     typedef unsigned char byte;
@@ -338,6 +338,9 @@ cdef = """
 
     extern int OLDTLS_ENABLED;
 
+    /*
+     * Opaque structs.
+     */
     typedef ... WOLFSSL_CTX;
     typedef ... WOLFSSL;
     typedef ... WOLFSSL_X509;
@@ -345,30 +348,41 @@ cdef = """
     typedef ... WOLFSSL_X509_STORE_CTX;
     typedef ... WOLFSSL_X509_NAME;
     typedef ... WOLFSSL_X509_NAME_ENTRY;
-    typedef ... WOLFSSL_ALERT_HISTORY;
     typedef ... WOLFSSL_METHOD;
     typedef ... WOLFSSL_ASN1_TIME;
     typedef ... WOLFSSL_ASN1_GENERALIZEDTIME;
     typedef ... WOLFSSL_ASN1_STRING;
     typedef ... WOLFSSL_ASN1_OBJECT;
 
+    /*
+     * Non-opaque structs, where we need access to fields.
+     */
+    typedef struct WOLFSSL_ALERT {
+        int code;
+        int level;
+    } WOLFSSL_ALERT;
+    typedef struct WOLFSSL_ALERT_HISTORY {
+        WOLFSSL_ALERT last_rx;
+        WOLFSSL_ALERT last_tx;
+    } WOLFSSL_ALERT_HISTORY;
+
     typedef int (*VerifyCallback)(int, WOLFSSL_X509_STORE_CTX*);
     typedef int pem_password_cb(char*, int, int, void*);
     typedef int (*CallbackSniRecv)(WOLFSSL*, int*, void*);
 
-    /**
+    /*
      * Memory
      */
     void  wolfSSL_Free(void*);
     void  wolfSSL_OPENSSL_free(void*);
 
-    /**
+    /*
      * Debugging
      */
     void wolfSSL_Debugging_ON();
     void wolfSSL_Debugging_OFF();
 
-    /**
+    /*
      * SSL/TLS Method functions
      */
 """
@@ -399,7 +413,7 @@ if OLDTLS_ENABLED:
 cdef += """
     WOLFSSL_METHOD* wolfTLSv1_2_method(void);
 
-    /**
+    /*
      * SSL/TLS Context functions
      */
     WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
@@ -422,7 +436,7 @@ cdef += """
             CallbackSniRecv);
     long wolfSSL_CTX_set_mode(WOLFSSL_CTX*, long);
 
-    /**
+    /*
      * SSL/TLS Session functions
      */
     void wolfSSL_Init();
@@ -449,7 +463,7 @@ cdef += """
     long          wolfSSL_ctrl(WOLFSSL*, int, long, void*);
     void          wolfSSL_set_connect_state(WOLFSSL*);
 
-    /**
+    /*
      * WOLFSSL_X509 functions
      */
     char*                    wolfSSL_X509_get_subjectCN(void*);
@@ -492,7 +506,7 @@ cdef += """
                                  WOLFSSL_X509_EXTENSION*);
     WOLFSSL_X509*            wolfSSL_X509_dup(WOLFSSL_X509*);
 
-    /**
+    /*
      * ASN.1
      */
     int                wolfSSL_ASN1_STRING_length(WOLFSSL_ASN1_STRING*);
@@ -508,7 +522,7 @@ cdef += """
     int                wolfSSL_ASN1_STRING_to_UTF8(unsigned char **, 
                            WOLFSSL_ASN1_STRING*);
 
-    /**
+    /*
      * Misc.
      */
     int           wolfSSL_library_init(void);


### PR DESCRIPTION
Because we access the fields of WOLFSSL_ALERT_HISTORY and WOLFSSL_ALERT directly in do_handshake, these structs can't be opaque, or an exception will be raised by FFI.