### PR TITLE
GitHub Actions: Lint with ruff instead of flake8

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,23 +18,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest tox
+        pip install pytest ruff tox
         pip install -r requirements/test.txt
-# Won't pass flake8 yet
-#    - name: Lint with flake8
-#      run: |
-#        # stop the build if there are Python syntax errors or undefined names
-#        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-#        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with ruff
+      run: ruff .
     - name: Test with tox
-      run: |
-        tox
+      run: tox

--- a/examples/client.py
+++ b/examples/client.py
@@ -156,7 +156,7 @@ def main():
         
         if not args.C:
             secure_socket.enable_crl(1)
-            secure_socket.load_crl_file(args.r, 1);
+            secure_socket.load_crl_file(args.r, 1)
         
         secure_socket.connect((args.h, args.p))
 

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,7 @@
 
 # pylint: disable=wrong-import-position
 
-import os
-import sys
 from setuptools import setup
-from setuptools.command.build_ext import build_ext
 
 import re
 VERSIONFILE = "wolfssl/_version.py"

--- a/wolfssl/__init__.py
+++ b/wolfssl/__init__.py
@@ -28,7 +28,7 @@ import sys
 from functools import wraps
 import errno
 from socket import (
-    socket, AF_INET, SOCK_STREAM, SOL_SOCKET, SO_TYPE, error as socket_error
+    socket, AF_INET, SOCK_STREAM, error as socket_error
 )
 
 # pylint: disable=wildcard-import
@@ -487,7 +487,7 @@ class SSLSocket(object):
         """
         Returns True for server-side socket, otherwise False.
         """
-        return self._server_side;
+        return self._server_side
 
     def dup(self):
         raise NotImplementedError("Can't dup() %s instances" %
@@ -998,5 +998,5 @@ class WolfsslPwd_cb(object):
             for i in range(len(result)):
                 passwd[i] = result[i:i + 1]
             return len(result)
-        except Exception as e:
+        except Exception:
             raise ValueError("Problem getting password from callback")

--- a/wolfssl/_build_ffi.py
+++ b/wolfssl/_build_ffi.py
@@ -22,7 +22,6 @@
 
 # pylint: disable=missing-docstring, invalid-name
 
-import argparse
 from contextlib import contextmanager
 from distutils.util import get_platform
 from cffi import FFI
@@ -105,7 +104,7 @@ def checkout_ref(ref):
             current = subprocess.check_output(
                 ["git", "describe", "--all", "--exact-match"]
             ).strip().decode().split('/')[-1]
-        except:
+        except Exception:
             pass
 
         if current != ref:


### PR DESCRIPTION
% `ruff .`
```
examples/client.py:159:51: E703 [*] Statement ends with an unnecessary semicolon
setup.py:24:8: F401 [*] `os` imported but unused
setup.py:25:8: F401 [*] `sys` imported but unused
setup.py:27:42: F401 [*] `setuptools.command.build_ext.build_ext` imported but unused
wolfssl/__init__.py:31:35: F401 [*] `socket.SOL_SOCKET` imported but unused
wolfssl/__init__.py:31:47: F401 [*] `socket.SO_TYPE` imported but unused
wolfssl/__init__.py:490:33: E703 [*] Statement ends with an unnecessary semicolon
wolfssl/__init__.py:1001:29: F841 [*] Local variable `e` is assigned to but never used
wolfssl/_build_ffi.py:25:8: F401 [*] `argparse` imported but unused
wolfssl/_build_ffi.py:108:9: E722 Do not use bare `except`
Found 10 errors.
[*] 9 fixable with the `--fix` option.
```
% `ruff --fix .`
```
wolfssl/_build_ffi.py:107:9: E722 Do not use bare `except`
Found 10 errors (9 fixed, 1 remaining).
```
% `code wolfssl/_build_ffi.py`
% `ruff rule E722`
# bare-except (E722)

Derived from the **pycodestyle** linter.

## What it does
Checks for bare `except` catches in `try`-`except` statements.

## Why is this bad?
A bare `except` catches `BaseException` which includes
`KeyboardInterrupt`, `SystemExit`, `Exception`, and others. Catching
`BaseException` can make it hard to interrupt the program (e.g., with
Ctrl-C) and can disguise other problems.

## Example
```python
try:
    raise KeyboardInterrupt("You probably don't mean to break CTRL-C.")
except:
    print("But a bare `except` will ignore keyboard interrupts.")
```

Use instead:
```python
try:
    do_something_that_might_break()
except MoreSpecificException as e:
    handle_error(e)
```

If you actually need to catch an unknown error, use `Exception` which will
catch regular program errors but not important system exceptions.

```python
def run_a_function(some_other_fn):
    try:
        some_other_fn()
    except Exception as e:
        print(f"How exceptional! {e}")
```

## References
- [Python documentation: Exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy)
- [Google Python Style Guide: "Exceptions"](https://google.github.io/styleguide/pyguide.html#24-exceptions)
