### PR TITLE
SSLSocket: support version() method

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ import ssl
 import pytest
 import wolfssl
 from wolfssl._ffi import lib as _lib
+from wolfssltestserver import wolfSSLTestServer
 
 @pytest.fixture
 def tcp_socket():
@@ -61,3 +62,15 @@ def ssl_context(ssl_provider, request):
         return ssl_provider.SSLContext(ssl_provider.PROTOCOL_TLSv1_3)
     if request.param == "SSLv23":
         return ssl_provider.SSLContext(ssl_provider.PROTOCOL_SSLv23)
+
+port = 1110
+@pytest.fixture
+def ssl_server():
+    from threading import Thread
+    global port
+    port += 1
+    with wolfSSLTestServer(('localhost', port)) as server:
+        t = Thread(target=server.handle_request)
+        t.daemon = True
+        t.start()
+        yield server

--- a/tests/wolfssltestserver.py
+++ b/tests/wolfssltestserver.py
@@ -1,0 +1,25 @@
+from wolfssl import SSLContext, PROTOCOL_TLS, CERT_NONE
+from socketserver import TCPServer, BaseRequestHandler
+
+ca_path = './certs/client-cert.pem'
+cert_path = './certs/server-cert.pem'
+key_path = './certs/server-key.pem'
+
+class wolfSSLTestServer(TCPServer):
+    class wolfSSLRequestHandler(BaseRequestHandler):
+        def handle(self):
+            ssl_socket = self.server.ctx.wrap_socket(self.request, server_side=True)
+            ssl_socket.recv(1024)
+            ssl_socket.sendall(b'I hear you fa shizzle!')
+    ctx = None
+    def __init__(self, address, version=PROTOCOL_TLS, ca=ca_path, cert=cert_path, key=key_path, verify=CERT_NONE):
+        TCPServer.__init__(self, address, self.wolfSSLRequestHandler, bind_and_activate=False)
+        self.allow_reuse_address = self.allow_reuse_port = True
+        self.ctx = SSLContext(version, server_side=True)
+        self.ctx.verify_mode = verify
+        self.ctx.load_verify_locations(ca)
+        self.ctx.load_cert_chain(cert, key)
+        self.port = address[1]
+        self.version = version
+        self.server_bind()
+        self.server_activate()

--- a/wolfssl/__init__.py
+++ b/wolfssl/__init__.py
@@ -857,6 +857,11 @@ class SSLSocket(object):
 
         return {'subject': ((('commonName', x509.get_subject_cn()),),),
                 'subjectAltName': x509.get_altnames() }
+    def version(self):
+        """
+        Returns the version of the protocol used in the connection.
+        """
+        return _ffi.string(_lib.wolfSSL_get_version(self.native_object)).decode("ascii")
 
     # The following functions expose functionality of the underlying
     # Socket object. These are also exposed through Python's ssl module

--- a/wolfssl/_build_ffi.py
+++ b/wolfssl/_build_ffi.py
@@ -485,6 +485,7 @@ cdef += """
     void*         wolfSSL_dtls_create_peer(int, char*);
     int           wolfSSL_dtls_free_peer(void*);
     int           wolfSSL_dtls_set_peer(WOLFSSL*, void*, unsigned int);
+    const char*   wolfSSL_get_version(const WOLFSSL*);
 
     /*
      * WOLFSSL_X509 functions


### PR DESCRIPTION
This is needed to support urllib3 1.26.18 port