### PR TITLE
wolfssl-py: support disabling secure renegotiation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,16 @@ wolfSSL library.  For example:
     # Uses custom install location
     $ USE_LOCAL_WOLFSSL=/tmp/install pip install .
 
+Disabling secure renegotiation
+------------------------------
+
+When building wolfssl-py from source secure renegotiation is enabled by
+default. To disable secure renegotiation set the environment variable
+WOLFSSLPY_DISABLE_SCR during the build process. For example:
+
+.. code-block:: bash
+    $ WOLFSSLPY_DISABLE_SCR=1 pip install .
+
 Testing
 =======
 

--- a/wolfssl/_build_ffi.py
+++ b/wolfssl/_build_ffi.py
@@ -142,6 +142,8 @@ def make_flags(prefix, debug):
     """
     flags = []
     cflags = []
+    # defaults to None (that eval to False)
+    disable_scr = os.getenv("WOLFSSLPY_DISABLE_SCR")
 
     if get_platform() in ["linux-x86_64", "linux-i686"]:
         cflags.append("-fpic")
@@ -171,7 +173,8 @@ def make_flags(prefix, debug):
     cflags.append("-DKEEP_PEER_CERT")
 
     # for pyOpenSSL
-    flags.append("--enable-secure-renegotiation")
+    if not disable_scr:
+        flags.append("--enable-secure-renegotiation")
     flags.append("--enable-opensslall")
     cflags.append("-DFP_MAX_BITS=8192")
     cflags.append("-DHAVE_EX_DATA")

--- a/wolfssl/_openssl.py
+++ b/wolfssl/_openssl.py
@@ -21,6 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
 # pylint: disable=missing-docstring, invalid-name
+import os
 
 source = """
     #include <wolfssl/options.h>
@@ -248,7 +249,6 @@ def construct_cdef(optional_funcs, OLDTLS_ENABLED):
         X509*         SSL_get_peer_certificate(SSL*);
         const char*   SSL_alert_type_string_long(int);
         const char*   SSL_alert_desc_string_long(int);
-        int           SSL_renegotiate(SSL*);
         void          SSL_get0_next_proto_negotiated(const SSL*,
                           const unsigned char**, unsigned*);
         const char*   SSL_get_servername(SSL*, unsigned char);
@@ -305,6 +305,13 @@ def construct_cdef(optional_funcs, OLDTLS_ENABLED):
         const char*   OBJ_nid2sn(int n);
         int           OBJ_txt2nid(const char*);
     """
+
+    # defaults to None (that eval to False)
+    disable_scr = os.getenv("WOLFSSLPY_DISABLE_SCR")
+    if not disable_scr:
+        cdef += """
+        int           SSL_renegotiate(SSL*);
+        """
 
     for func in optional_funcs:
         cdef += "{};".format(func.ossl_sig)


### PR DESCRIPTION
Use environment variable WOLFSSLPY_DISABLE_SCR to build with secure renegotiation disabled.